### PR TITLE
WIP: Add support instream video ads for medianetAnalyticsAdapter

### DIFF
--- a/modules/dfpAdServerVideo.js
+++ b/modules/dfpAdServerVideo.js
@@ -8,6 +8,8 @@ import { deepAccess, isEmpty, logError, parseSizesInput, formatQS, parseUrl, bui
 import { config } from '../src/config.js';
 import { getHook, submodule } from '../src/hook.js';
 import { auctionManager } from '../src/auctionManager.js';
+import events from '../src/events.js';
+import CONSTANTS from '../src/constants.json';
 
 /**
  * @typedef {Object} DfpVideoParams
@@ -253,8 +255,10 @@ function getCustParams(bid, options) {
     { hb_cache_id: bid && bid.videoCacheKey },
     allTargetingData,
     adserverTargeting,
-    optCustParams,
   );
+
+  events.emit(CONSTANTS.EVENTS.SET_TARGETING, {[adUnit.code]: customParams});
+  customParams = Object.assign(customParams, optCustParams)
   return encodeURIComponent(formatQS(customParams));
 }
 


### PR DESCRIPTION
## Type of change
<!-- Remove items that don't apply and/or select an item by changing [ ] to [x] -->
- [x] Bugfix
- [x] Feature
documentation here https://github.com/prebid/prebid.github.io/tree/master/dev-docs/bidders --> 
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Does this change affect user-facing APIs or examples documented on http://prebid.org?
- [ ] Other

## Description of change
Add support instream video ads for medianetAnalyticsAdapter

## Problem:
- Inability to track BID WON or rendered for events of instream or ad pod inventories by client analytics adapters

## Possible Solution for #5308:
Since we know for sure every type of bid response will have videoCacheKey and will be loaded by VideoPlayer. We can use the Performance API to keep track of any resource fired with a video cache key.


