### PR TITLE
Fix ES5 node_modules transform in webpack config

### DIFF
--- a/webpack.conf.js
+++ b/webpack.conf.js
@@ -75,7 +75,16 @@ module.exports = {
           const babelConfig = require('./babelConfig.js')({disableFeatures: helpers.getDisabledFeatures(), ES5: true});
           return [
             {
-              test: /\.node_modules\/.*\.js$/,
+              test: /\.mjs$/,
+              type: 'javascript/auto',
+              resolve: { fullySpecified: false },
+            },
+            {
+              test: /node_modules\/.*\.[cm]?js$/,
+              exclude: [
+                /node_modules[\\/]core-js[\\/]/,
+                /node_modules[\\/]core-js$/,
+              ],
               use: [
                 {
                   loader: 'babel-loader',


### PR DESCRIPTION
## ES5 `node_modules` Transform Is Broken

### Build Type

**ES5 build**: A legacy-compatible bundle triggered via the `--ES5` flag. It transpiles code to ES5 syntax to support older browsers that do not support modern JavaScript features.

### Current Problem

Prebid source code is transformed for ES5, but vendor code from `node_modules` can bypass Babel and leak modern syntax into the final bundle.

For example, syntax such as optional chaining `?.` or nullish coalescing `??` can remain in vendor modules.

The ES5 vendor rule in `webpack.conf.js` currently does not match normal vendor files:

```js
test: /\.node_modules\/.*\.js$/,
```

This has two problems:

- It expects `.node_modules` instead of `node_modules`.
- It only matches `.js`, missing `.cjs` and `.mjs` packages such as `live-connect-js/dist/index.cjs`.

### Suggested Fix

Fix the vendor matcher for the ES5 build:

```diff
- test: /\.node_modules\/.*\.js$/,
+ test: /node_modules\/.*\.[cm]?js$/,
```

Also keep the ES5 guardrails:

```js
{
  test: /\.mjs$/,
  type: 'javascript/auto',
  resolve: { fullySpecified: false },
},
{
  test: /node_modules\/.*\.[cm]?js$/,
  exclude: [
    /node_modules[\\/]core-js[\\/]/,
    /node_modules[\\/]core-js$/,
  ],
  use: [/* babel-loader */],
}
```

`core-js` should be excluded because it is the polyfill implementation itself. Re-processing it through Babel can corrupt internal helper modules and cause runtime errors such as `$ is not a function`.

`.mjs` files should be treated as `javascript/auto` because the ES5 Babel config rewrites ESM exports to CommonJS-style exports. Webpack treats `.mjs` as strict ESM by default, where `exports` is unavailable, which can otherwise cause runtime errors like `exports is not defined`.

### Expected Result

The ES5 build should:

- Transform vendor code from `node_modules`.
- Include `.js`, `.cjs`, and `.mjs` vendor packages.
- Avoid re-transforming `core-js`.
- Handle `.mjs` vendor packages without `exports is not defined` runtime errors.

### Steps To Reproduce

```bash
gulp build-bundle-prod --ES5
grep -c 'gppApplicableSections?.join' build/dist/prebid.js
```
